### PR TITLE
Fix: RN release mode crash

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
  * @format
  */
 
+import 'react-native-gesture-handler'; // Navigation Release Mode Crash issue #320
 import { AppRegistry } from 'react-native';
 import App from './app/app';
 import { name as appName } from './app.json';


### PR DESCRIPTION
The commit fixes the react-navigation crash issue on release mode, moving between screens.

For more detail:

https://github.com/kmagiera/react-native-gesture-handler/issues/320